### PR TITLE
Adding radius in blockquote for consistent styling

### DIFF
--- a/src/elements/blockquote.js
+++ b/src/elements/blockquote.js
@@ -12,6 +12,7 @@ export default class NuBlockQuote extends NuElement {
   static get nuStyles() {
     return {
       display: 'block',
+      radius: '0r 1r 1r 0r',
       border: '(1x / 2) left #special',
       fill: 'diff',
       text: 'i',

--- a/src/elements/blockquote.js
+++ b/src/elements/blockquote.js
@@ -12,7 +12,7 @@ export default class NuBlockQuote extends NuElement {
   static get nuStyles() {
     return {
       display: 'block',
-      radius: '0r 1r 1r 0r',
+      radius: 'right',
       border: '(1x / 2) left #special',
       fill: 'diff',
       text: 'i',


### PR DESCRIPTION
`radius: 'right'`
with new radius syntax